### PR TITLE
fix: correct arrow direction for negative changes

### DIFF
--- a/src/design/components/KpiCard.vue
+++ b/src/design/components/KpiCard.vue
@@ -127,12 +127,14 @@ const showChange = computed(() => props.changeLabel !== undefined || props.chang
 const changeIcon = computed(() => {
   if (typeof props.change !== 'number') return null
 
+  // 箭頭方向應該根據數值變化，而非 trend
+  // trend 只影響顏色（好/壞）
   if (props.change > 0) {
-    return props.trend === 'down' ? 'i-ph-trend-down' : 'i-ph-trend-up'
+    return 'i-ph-trend-up'  // 正數永遠向上
   } else if (props.change < 0) {
-    return props.trend === 'up' ? 'i-ph-trend-up' : 'i-ph-trend-down'
+    return 'i-ph-trend-down'  // 負數永遠向下
   }
-  
+
   return 'i-ph-minus'
 })
 


### PR DESCRIPTION
  CU-86euy2e5b
  
  in KPI cards

  - Arrow direction now based solely on numeric change (positive=up, negative=down)
  - Trend property only affects color (green/red) not arrow direction
  - Fixed issue where negative values showed upward arrow incorrectly